### PR TITLE
feat: use commitizen to control versions of this repository

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,7 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_scheme = "semver"
+version = "0.3.2"
+update_changelog_on_bump = true
+major_version_zero = true

--- a/.github/workflows/_bump-call.yml
+++ b/.github/workflows/_bump-call.yml
@@ -1,0 +1,45 @@
+# This is NOT a reusable workflow, and is not part of the public API.
+#
+# This workflow is triggered by a push to the main branch or manually via
+# workflow_dispatch. It runs the bump version job to update the package
+# version in the repository. The job will only run if the last commit message
+# does not start with 'bump:'. This is to prevent accidental bumps when the
+# commit message is not intended to trigger a version bump.
+#
+# * The bumped version is pushed to the repository.
+# * The workflow uses a service token for authentication.
+# * The concurrency group ensures that only one bump job runs at a time for the
+#   same branch.
+# * The workflow runs on the main branch.
+name: Bump Version
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write    # needed to push commits/tags
+  id-token: write    # needed if your reusable workflow exchanges OIDC tokens
+
+concurrency:
+  group: bump-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    # Only run when:
+    #  • There was a push to main and the head commit message doesn't start
+    #    with 'bump:'
+    #  • OR this is a manual dispatch
+    if: >
+      (github.event_name == 'push' &&
+       github.ref == 'refs/heads/main' &&
+       !startsWith(github.event.head_commit.message, 'bump:')) ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main')
+    uses: ./.github/workflows/bump-version.yml
+    with:
+      default-branch: main
+    secrets:
+      repo-token: ${{ secrets.SERVICE_TOKEN }}

--- a/.github/workflows/_move-major-branch.yml
+++ b/.github/workflows/_move-major-branch.yml
@@ -1,0 +1,88 @@
+# This is NOT a reusable workflow, and is not part of the public API.
+#
+# This workflow is triggered by a push to a version tag (e.g. v1.2.3) or
+# manually via workflow_dispatch. It moves the commit pointed to by the tag to
+# a major branch (e.g. v1, v2, etc.). For v0.x.y releases, it creates branches
+# like v0.x (e.g. v0.3 for v0.3.5). If the major branch already exists, it
+# will reset it to the commit of the tag. If it does not exist, it will create
+# the branch at the commit of the tag.
+name: "Move/update major branch"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to process (e.g. v3.2.1 creates v3 branch, v0.3.5 creates v0.3 branch)"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: move-major-branch
+  cancel-in-progress: false
+
+jobs:
+  move-major-branch:
+    runs-on: ubuntu-latest
+    steps:
+      # 1) Check out repo so we can move branches
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SERVICE_TOKEN }}
+
+      # 2) Work out which tag & commit we’re supposed to handle
+      - name: Determine tag & commit
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+            # Make sure the tag exists locally
+            if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+              echo "::error::Tag '${TAG}' not found in origin; did you push it?"
+              exit 1
+            fi
+            COMMIT=$(git rev-parse "refs/tags/${TAG}^{commit}")
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            COMMIT="${GITHUB_SHA}"
+          fi
+
+          # Extract the target branch based on semver, handling v0.x.y specially
+          if [[ "${TAG}" =~ ^v0\. ]]; then
+            # For v0.x.y releases, use v0.x as the target branch
+            TARGET_BRANCH=$(echo "${TAG}" | cut -d. -f1,2)  # e.g. v0.3.5 -> v0.3
+          else
+            # For v1.x.y and above, use just the major version
+            TARGET_BRANCH="${TAG%%.*}"                      # e.g. v1.2.3 -> v1
+          fi
+
+          echo "tag=${TAG}"       >>"$GITHUB_OUTPUT"
+          echo "commit=${COMMIT}" >>"$GITHUB_OUTPUT"
+          echo "target_branch=${TARGET_BRANCH}"   >>"$GITHUB_OUTPUT"
+
+
+      # 3) Fast‑forward or create the major branch
+      - name: Move or create major branch
+        env:
+          TARGET_BRANCH:  ${{ steps.vars.outputs.target_branch }}
+          COMMIT: ${{ steps.vars.outputs.commit }}
+        run: |
+          set -euo pipefail
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null; then
+            echo "Resetting branch $TARGET_BRANCH to $COMMIT"
+            git branch -f "$TARGET_BRANCH" "$COMMIT"
+          else
+            echo "Creating new branch $TARGET_BRANCH at $COMMIT"
+            git branch "$TARGET_BRANCH" "$COMMIT"
+          fi
+          git push origin "$COMMIT:refs/heads/$TARGET_BRANCH" --force-with-lease

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -1,0 +1,43 @@
+# This is NOT a reusable workflow, and is not part of the public API.
+#
+# This workflow is triggered by a push to a version tag (e.g. v1.2.3) or
+# manually via workflow_dispatch. It creates a GitHub release and uploads the
+# built artifacts.
+# * The concurrency group ensures that only one release job runs at a time.
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'          # semver tags
+  workflow_dispatch:
+
+permissions:
+  contents: write    # create release + upload assets
+
+concurrency:
+  group: release
+  cancel-in-progress: false   # let releases finish
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    # only run on a tag push, or on a manual dispatch *where* the user has
+    # selected a tag ref (i.e. github.ref starts with refs/tags/)
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # on push this is already the tag ref; on dispatch you must choose
+          # the tag in the UI so github.ref is the tag
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ aind-github-actions
 
 ## This repository is for workflows that may be reused in other workflows and repositories.
 
-GitHub actions workflows are found in .github/workflows.
+GitHub actions workflows are found in .github/workflows. Any workflows that have
+an underscore at the start of their name are NOT part of the API, and are
+internal to this repository.
 
 Example calling workflows are in `examples/`
 


### PR DESCRIPTION
In addition, automatically track the major/0.x series as a branch, allowing downstream use of SemVer for this repository. Also create GitHub releases on new tags.

NOTE: workflows must be in workflow folder, so these "private" workflows meant to maintain the repository, instead of being consumed by other repositories, have a preceding underscore in their name.