### PR TITLE
ci: updates version and date-released in citation.cff file

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,11 +1,4 @@
-# Call this workflow like this:
-# jobs:
-#   bump-version:
-#     uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml
-#     with:
-#       default_branch: main # optional, default: main
-#     secrets:
-#       SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }} # required
+name: Tag
 
 on:
   workflow_call:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -60,6 +60,13 @@ jobs:
           sed -i --debug --expression='s/^version: .*/version: "v${{ env.VERSION }}"/' CITATION.cff
           sed -i --debug --expression="s/^date-released: .*/date-released: $(date +%Y-%m-%d)/" CITATION.cff
         fi
+    - name: Set files to commit
+      run: |
+        files_to_add="${{ env.VERSION_FILE }}"
+        if [ -f CITATION.cff ]; then
+          files_to_add="$files_to_add CITATION.cff"
+        fi
+        echo "FILES_TO_ADD=$files_to_add" >> "$GITHUB_ENV"
     - name: Set output
       id: output_version
       run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
@@ -68,7 +75,7 @@ jobs:
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
-        add: ${{ env.VERSION_FILE }} CITATION.cff
+        add: ${{ env.FILES_TO_ADD }}
     - name: Update tag
       run: |
         git tag v${{ env.VERSION }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         default_author: github_actions
         message: "ci: version bump [skip actions]"
-        add: ${{ env.VERSION_FILE }}
+        add: ${{ env.VERSION_FILE }} CITATION.cff
     - name: Update tag
       run: |
         git tag v${{ env.VERSION }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -54,6 +54,12 @@ jobs:
       run: |
         grep "__version__" "$VERSION_FILE"
         sed -i --debug --expression="s|__version__.*|__version__ = \"${{ env.VERSION }}\"|" "$VERSION_FILE"
+    - name: Update version in CITATION.cff file
+      run: |
+        if [ -f CITATION.cff ]; then
+          sed -i --debug --expression='s/^version: .*/version: "v${{ env.VERSION }}"/' CITATION.cff
+          sed -i --debug --expression="s/^date-released: .*/date-released: $(date +%Y-%m-%d)/" CITATION.cff
+        fi
     - name: Set output
       id: output_version
       run: echo "new_version=${{ env.VERSION }}" >> "$GITHUB_OUTPUT"

--- a/examples/tag-call.yml
+++ b/examples/tag-call.yml
@@ -1,0 +1,21 @@
+# Example workflow to use the reusable tag workflow
+# This workflow is triggered after CI tests pass to create a new Git tag
+# It updates the version number in the codebase and creates a new Git tag.
+# * This workflow should be placed in `.github/workflows/tag_and_publish.yml`
+# of your repository.
+# * The workflow uses a service token for authentication to commit changes.
+
+name: Tag
+
+on:
+  push:
+    branches:
+      - main  # or your default branch
+
+jobs:
+  bump-version:
+    uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
+    with:
+      default_branch: main # optional, default: main
+    secrets:
+      SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }} # required


### PR DESCRIPTION
Fixes https://github.com/AllenNeuralDynamics/aind-library-template/issues/101

- Adds a step in bump-version job that updates `version` and `date-released` in CITATION.cff file (if it exists)